### PR TITLE
Align split sections to top

### DIFF
--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
     .lesson .num{font-weight:900;color:var(--brand)}
 
     /* Split sections */
-    .split{display:grid;grid-template-columns:1fr 1fr;gap:40px;align-items:center;padding:64px 24px}
+    .split{display:grid;grid-template-columns:1fr 1fr;gap:40px;align-items:start;padding:64px 24px}
     .split h2{font-size:clamp(1.4rem,3.2vw,2rem);margin:0 0 10px}
     .split p{color:#475569}
 


### PR DESCRIPTION
## Summary
- Align split sections to top to prevent vertical centering

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68addffcefd88331a72b279140669fae