### PR TITLE
Add hero image and parrot favicon

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,6 +9,7 @@
   <meta property="og:description" content="A free, story-driven GPT for teaching AI & prompting in 5 fun, structured lessons. Built for teachers." />
   <meta property="og:type" content="website" />
   <meta name="theme-color" content="#0ea5e9" />
+  <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22%3E%3Ctext y=%220.9em%22 font-size=%2290%22%3E🦜%3C/text%3E%3C/svg%3E" />
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;700;800&family=Montserrat:wght@700;800&display=swap" rel="stylesheet">
@@ -128,23 +129,12 @@
           <a class="btn outline" href="#map">View Lesson Map</a>
         </div>
       </div>
-      <div>
-        <svg class="floaty" viewBox="0 0 560 420" width="100%" aria-hidden="true">
-          <defs>
-            <linearGradient id="sea" x1="0" x2="1"><stop offset="0%" stop-color="#0ea5e9"/><stop offset="100%" stop-color="#22c55e"/></linearGradient>
-          </defs>
-          <rect x="0" y="0" width="560" height="420" rx="24" fill="#ffffff" stroke="#e2e8f0"/>
-          <ellipse cx="280" cy="350" rx="220" ry="24" fill="#0ea5e922"/>
-          <circle cx="420" cy="80" r="14" fill="#f59e0b"/>
-          <path d="M90 320c40-50 110-70 170-58 42 8 84 6 126-18 22-13 49-40 79-83 12 62-1 105-39 129-26 17-74 34-146 24-70-9-155 41-190 6z" fill="#d9f99d"/>
-          <path d="M210 250c20 6 34 1 46-10 10-9 25-12 40-6 13 6 29 4 42-2 25-12 52-52 80-118" fill="none" stroke="url(#sea)" stroke-width="6" stroke-linecap="round"/>
-          <text x="40" y="60" font-family="Montserrat, sans-serif" font-size="28" font-weight="800" fill="#0b1220">Exploring Prompt Island</text>
-          <text x="40" y="92" font-family="Nunito, sans-serif" font-size="16" fill="#334155">Story-led lessons • Badges • Teacher-friendly pacing</text>
-        </svg>
+        <div>
+          <img src="ProfessorCoco.png" alt="Professor Coco" class="floaty" width="100%" />
+        </div>
       </div>
-    </div>
-    <div class="island"></div>
-  </header>
+      <div class="island"></div>
+    </header>
 
   <!-- WHY TEACHERS LOVE IT -->
   <section class="features">


### PR DESCRIPTION
## Summary
- Replace hero illustration with Professor Coco image
- Set 🦜 emoji as the site favicon

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ade82ed7048331af5dc92024aead17